### PR TITLE
Calender and menu fix

### DIFF
--- a/src/pages/Calendar.js
+++ b/src/pages/Calendar.js
@@ -1,17 +1,11 @@
-import ReactMarkdown from 'react-markdown';
 import React from "react";
 import { fetchRichText } from "../utils/api_helpers";
 
 export function Calendar() {
     const [pageTitle, setPageTitle] = React.useState(null);
-    const [calendarText, setCalendarText] = React.useState(null);
 
     React.useEffect(() => {
         fetchRichText((data) => {
-            if (data?.text) {
-                setCalendarText(data?.text)
-            }
-
             if (data?.title) {
                 setPageTitle(data?.title)
             }
@@ -22,7 +16,11 @@ export function Calendar() {
         <main className="container">
             <section className="section text-section">
                 {pageTitle && <h1 className="subheader-h1">{pageTitle}</h1>}
-                <ReactMarkdown>{calendarText}</ReactMarkdown>
+                <iframe src="https://calendar.google.com/calendar/embed?height=600&wkst=2&bgcolor=%233F51B5&ctz=Europe%2FStockholm&src=c2pva3JvZ2dldGZvdGVuQGdtYWlsLmNvbQ&src=c3Yuc3dlZGlzaCNob2xpZGF5QGdyb3VwLnYuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&color=%23039BE5&color=%230B8043"
+                    title="Kalender"
+                    style={{ border: 0, width: "100%", maxWidth: "800px", height: "600px" }}
+                    allowFullScreen="">
+                </iframe>
             </section>
         </main>);
 

--- a/src/pages/Meny.js
+++ b/src/pages/Meny.js
@@ -5,7 +5,6 @@ import { fetchMenues } from "../utils/api_helpers";
 export function Meny() {
 
   const [menuUrl, setMenuUrl] = React.useState(null);
-  const [drinMenukUrl, setDrinkMenuUrl] = React.useState(null);
 
   React.useEffect(() => {
     fetchMenues((menuUrl, drinkMenuUrl) => {
@@ -13,11 +12,6 @@ export function Meny() {
       if (menuUrl) {
         const menuFileHref = process.env.REACT_APP_URLBASE + menuUrl
         setMenuUrl(menuFileHref);
-      }
-
-      if (drinkMenuUrl) {
-        const drinkMenuFileHref = process.env.REACT_APP_URLBASE + drinkMenuUrl
-        setDrinkMenuUrl(drinkMenuFileHref);
       }
 
     });
@@ -29,7 +23,6 @@ export function Meny() {
       <section className="section text-section">
         <h1>Meny</h1>
         <p>Menyn kan laddas ner <a target="_blank" rel="noreferrer" href={menuUrl}>här</a>.</p>
-        <p>Drink menyn kan laddas ner <a target="_blank" rel="noreferrer" href={drinMenukUrl}>här</a>.</p>
       </section>
     </main>
   );


### PR DESCRIPTION
Ad-hock fix only fixing front-end to:
- Replace calender text with google calender
-  Remove showing drink menue